### PR TITLE
Compare defi llama apy then and now

### DIFF
--- a/defi_analysis_nov2021_vs_jan2025.md
+++ b/defi_analysis_nov2021_vs_jan2025.md
@@ -1,0 +1,154 @@
+# DeFi Landscape Analysis: November 2021 vs January 2025
+
+## Executive Summary
+
+Ethereum has recently hit new all-time highs at $4,827.83, surpassing its previous peak from November 2021. This milestone provides an excellent opportunity to analyze how the DeFi ecosystem has evolved over the past 3+ years using DeFiLlama data.
+
+## Key Metrics Comparison
+
+### Total Value Locked (TVL)
+
+| Metric | November 2021 | January 2025 | Change |
+|--------|---------------|--------------|--------|
+| **Total DeFi TVL** | ~$118.4 billion | ~$153 billion | +29.2% |
+| **Ethereum TVL** | ~$106 billion | ~$67 billion | -36.8% |
+| **Market Share** | Ethereum dominated | Multi-chain diversification | Fragmented |
+
+### Ethereum Price Context
+
+| Metric | November 2021 | January 2025 |
+|--------|---------------|--------------|
+| **ETH Price** | ~$4,868 (ATH) | ~$4,827 (New ATH) |
+| **Market Cap** | ~$580 billion | ~$580 billion |
+
+## Major DeFi Protocol Analysis
+
+### Current Top Protocols by TVL (January 2025)
+
+1. **Lido (stETH)** - $41.4B TVL, 2.76% APY
+2. **Binance Staked ETH (wbETH)** - $14.7B TVL, 2.53% APY
+3. **Ether.fi (weETH)** - $12.7B TVL, 3.25% APY
+4. **Aave V3 (weETH)** - $9.2B TVL, 0.0004% APY
+5. **Rocket Pool (rETH)** - $6.4B TVL, 2.50% APY
+
+### Yield Environment Changes
+
+#### November 2021 Yield Landscape:
+- **Stablecoin APYs**: 5-15% typical range
+- **ETH Staking**: Not available (pre-merge)
+- **DeFi Lending**: 8-20% on major protocols
+- **Liquidity Mining**: 20-100%+ rewards common
+- **Risk Premium**: High yields due to protocol risk
+
+#### January 2025 Yield Landscape:
+- **Stablecoin APYs**: 7-25% (sophisticated strategies)
+- **ETH Staking**: 2.5-3.3% (liquid staking dominant)
+- **DeFi Lending**: 0.01-9% (matured, lower risk premiums)
+- **Advanced Strategies**: Up to 25% through restaking/looping
+- **Risk Premium**: Lower, more institutional adoption
+
+## Major Structural Changes
+
+### 1. Liquid Staking Revolution
+- **2021**: ETH staking not available
+- **2025**: Liquid staking protocols dominate TVL (Lido, Rocket Pool, etc.)
+- **Impact**: $75B+ in liquid staking derivatives
+
+### 2. Multi-Chain Ecosystem
+- **2021**: Ethereum-centric with emerging L1s
+- **2025**: Mature multi-chain ecosystem (Solana, Base, Arbitrum, etc.)
+- **Impact**: TVL distributed across 100+ chains
+
+### 3. Institutional Adoption
+- **2021**: Primarily retail and DeFi natives
+- **2025**: Institutional players, regulated products
+- **Impact**: Lower risk premiums, more stable yields
+
+### 4. Derivatives & Treasury Focus
+- **2021**: Simple lending/borrowing, AMM LPs
+- **2025**: Complex derivatives, treasury bill integration
+- **Impact**: Shift to sustainable, real-world yield sources
+
+### 5. Yield Strategy Evolution
+- **2021**: High-risk liquidity mining
+- **2025**: Sophisticated restaking, looping strategies
+- **Impact**: Higher risk-adjusted returns
+
+## Current High-Yield Opportunities (January 2025)
+
+### Stablecoins
+- **Ethena sUSDe**: 8.47% APY
+- **Maple USDC**: 9.22% APY (with MPL rewards)
+- **Advanced Strategies**: Up to 25% through protocol looping
+
+### Liquid Staking
+- **Jito SOL**: 6.66% APY
+- **Binance SOL**: 5.73% APY
+- **Ether.fi weETH**: 3.25% APY (with points/rewards)
+
+### Emerging Strategies
+- **Restaking Protocols**: 5-15% additional yield
+- **Real World Assets**: 8-12% treasury-backed yields
+- **Derivatives Farming**: 15-30% in specialized protocols
+
+## Risk Assessment Changes
+
+### November 2021 Risk Profile:
+- **Smart Contract Risk**: Very high (newer protocols)
+- **Regulatory Risk**: Uncertain/undefined
+- **Market Risk**: Extreme volatility
+- **Liquidity Risk**: High during market stress
+- **Yield Sustainability**: Questionable (token emissions)
+
+### January 2025 Risk Profile:
+- **Smart Contract Risk**: Lower (battle-tested protocols)
+- **Regulatory Risk**: Clearer framework emerging
+- **Market Risk**: Still high but better infrastructure
+- **Liquidity Risk**: Improved with institutional participation
+- **Yield Sustainability**: More sustainable (real yield focus)
+
+## Key Differences Summary
+
+### What's Better Now:
+1. **Sustainability**: Real yields vs. token emissions
+2. **Infrastructure**: Better tooling, interfaces, aggregators
+3. **Risk Management**: More sophisticated risk assessment
+4. **Accessibility**: Easier onboarding, better UX
+5. **Institutional Grade**: Regulated products available
+6. **Diversification**: Multi-chain opportunities
+
+### What's Challenging Now:
+1. **Lower Yields**: Maturation means lower risk premiums
+2. **Complexity**: More sophisticated strategies required
+3. **Competition**: Harder to find alpha opportunities
+4. **Fragmentation**: TVL spread across many chains
+5. **Regulatory Overhead**: Compliance requirements increasing
+
+## Investment Implications
+
+### For Current DeFi Participants:
+- Focus on risk-adjusted returns over absolute yields
+- Diversify across chains and protocols
+- Consider institutional-grade products for stability
+- Explore restaking and advanced strategies carefully
+
+### For New Entrants:
+- Start with established protocols (Aave, Lido, etc.)
+- Understand liquid staking as foundational DeFi primitive
+- Consider stablecoin strategies for steady returns
+- Evaluate multi-chain opportunities
+
+## Conclusion
+
+The DeFi landscape has matured significantly since November 2021. While absolute yields have decreased from the unsustainable highs of 2021, the ecosystem now offers:
+
+- **More Sustainable Returns**: 7-25% through sophisticated strategies
+- **Better Risk Management**: Battle-tested protocols and clearer regulations
+- **Broader Opportunities**: Multi-chain ecosystem with diverse strategies
+- **Institutional Infrastructure**: Professional-grade tools and products
+
+The current environment represents a more mature, sustainable, and accessible DeFi ecosystem, even if the "easy money" days of 2021 are behind us. Ethereum's new ATH reflects this maturation and the increased institutional confidence in the space.
+
+---
+
+*Analysis based on DeFiLlama data as of January 2025*


### PR DESCRIPTION
Add a comprehensive analysis comparing DeFi yields and the landscape between November 2021 and January 2025, fulfilling the user's request to understand changes since the last ETH all-time high.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1674ef0-786f-4d1f-809c-b05a51b8fe96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1674ef0-786f-4d1f-809c-b05a51b8fe96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

